### PR TITLE
Format with go fmt

### DIFF
--- a/main.go
+++ b/main.go
@@ -2,61 +2,61 @@
 package bands
 
 import (
-  "github.com/yujinlim/go-bandsintown/model"
-  "github.com/tj/go-debug"
-  "fmt"
+	"fmt"
+	"github.com/tj/go-debug"
+	"github.com/yujinlim/go-bandsintown/model"
 )
 
 var trace = debug.Debug("bands:log")
 
 const (
-  API_ROUTE   = "http://api.bandsintown.com/"
-  ARTIST_PATH = "artists"
-  EVENTS_PATH = "events"
-  VERSION     = "2.0"
-  URL         = API_ROUTE + ARTIST_PATH
+	API_ROUTE   = "http://api.bandsintown.com/"
+	ARTIST_PATH = "artists"
+	EVENTS_PATH = "events"
+	VERSION     = "2.0"
+	URL         = API_ROUTE + ARTIST_PATH
 )
 
 type ArtistApi interface {
-  GetArtist()       model.Artist
-  GetArtistEvents() []model.Event
+	GetArtist() model.Artist
+	GetArtistEvents() []model.Event
 }
 
 type Client struct {
-  API_KEY string
+	API_KEY string
 }
 
 // create new bandsintown api client
 func New(key string) *Client {
-  m := Client{key}
-  return &m
+	m := Client{key}
+	return &m
 }
 
 // get artist information based on artist name
-func (c *Client) GetArtist(name string) (model.Artist, error)  {
-  var artist model.Artist
-  url    := fmt.Sprintf("%s/%s?app_id=%s&api_version=%s&format=json", URL, name, c.API_KEY, VERSION)
+func (c *Client) GetArtist(name string) (model.Artist, error) {
+	var artist model.Artist
+	url := fmt.Sprintf("%s/%s?app_id=%s&api_version=%s&format=json", URL, name, c.API_KEY, VERSION)
 
-  if err := get(url, &artist); err != nil {
-    return artist, err
-  }
+	if err := get(url, &artist); err != nil {
+		return artist, err
+	}
 
-  trace("artist %s", artist)
+	trace("artist %s", artist)
 
-  return artist, nil
+	return artist, nil
 }
 
 // get artist's events by name
 func (c Client) GetArtistEvents(name string) ([]model.Event, error) {
-  var events []model.Event
-  url    := fmt.Sprintf("%s/%s/events?app_id=%s&api_version=%s&format=json", URL, name, c.API_KEY, VERSION)
+	var events []model.Event
+	url := fmt.Sprintf("%s/%s/events?app_id=%s&api_version=%s&format=json", URL, name, c.API_KEY, VERSION)
 
-  if err := get(url, &events); err != nil {
-    trace("error %s", err)
-    return events, err
-  }
+	if err := get(url, &events); err != nil {
+		trace("error %s", err)
+		return events, err
+	}
 
-  trace("events %d", len(events))
+	trace("events %d", len(events))
 
-  return events, nil
+	return events, nil
 }

--- a/main_test.go
+++ b/main_test.go
@@ -1,55 +1,55 @@
 package bands
 
 import (
-  "testing"
-  "errors"
-  "github.com/stretchr/testify/assert"
+	"errors"
+	"github.com/stretchr/testify/assert"
+	"testing"
 )
 
 const (
-  APP_ID         = "barcelona"
-  VALID_ARTIST   = "Skrillex"
-  INVALID_ARTIST = "donotexists"
+	APP_ID         = "barcelona"
+	VALID_ARTIST   = "Skrillex"
+	INVALID_ARTIST = "donotexists"
 )
 
 var artists = []string{
-  "mbid_65f4f0c5-ef9e-490c-aee3-909e7ae6b2ab",
-  "Skrillex",
-  "fbid_6885814958",
+	"mbid_65f4f0c5-ef9e-490c-aee3-909e7ae6b2ab",
+	"Skrillex",
+	"fbid_6885814958",
 }
 
 var client = New(APP_ID)
 
 func TestAcceptKey(t *testing.T) {
-  assert.Equal(t, client.API_KEY, APP_ID, "app id is not the same")
+	assert.Equal(t, client.API_KEY, APP_ID, "app id is not the same")
 }
 
 func TestGetArtist(t *testing.T) {
-  for _, artistName := range artists {
-    artist, err := client.GetArtist(artistName)
+	for _, artistName := range artists {
+		artist, err := client.GetArtist(artistName)
 
-    assert.Nil(t, err)
-    assert.NotEmpty(t, artist, "artist return is incorrect")
-  }
+		assert.Nil(t, err)
+		assert.NotEmpty(t, artist, "artist return is incorrect")
+	}
 }
 
 func TestGetArtistEvents(t *testing.T) {
-  events, err := client.GetArtistEvents(VALID_ARTIST)
+	events, err := client.GetArtistEvents(VALID_ARTIST)
 
-  assert.Nil(t, err)
-  assert.True(t, len(events) > 0, "events should return more than 1")
+	assert.Nil(t, err)
+	assert.True(t, len(events) > 0, "events should return more than 1")
 }
 
 func TestGetArtistNotFound(t *testing.T) {
-  _, err := client.GetArtistEvents(INVALID_ARTIST)
+	_, err := client.GetArtistEvents(INVALID_ARTIST)
 
-  assert.Error(t, err, "does not return Unknown Artist error object")
-  assert.Equal(t, err, errors.New("Unknown Artist"))
+	assert.Error(t, err, "does not return Unknown Artist error object")
+	assert.Equal(t, err, errors.New("Unknown Artist"))
 }
 
 func TestNotFound(t *testing.T) {
-  _, err := client.GetArtist("test/test")
+	_, err := client.GetArtist("test/test")
 
-  assert.Error(t, err, "does not return 404 error")
-  assert.Equal(t, err, errors.New("status code 404"))
+	assert.Error(t, err, "does not return 404 error")
+	assert.Equal(t, err, errors.New("status code 404"))
 }

--- a/util.go
+++ b/util.go
@@ -1,61 +1,61 @@
 package bands
 
 import (
-  "net/http"
-  "io"
-  "io/ioutil"
-  "encoding/json"
-  "errors"
-  "fmt"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
 )
 
 func getError(responseBody io.ReadCloser) string {
-  errorResponse := map[string][]string{}
+	errorResponse := map[string][]string{}
 
-  readBody(responseBody, &errorResponse)
+	readBody(responseBody, &errorResponse)
 
-  if len(errorResponse["errors"]) > 0 {
-    return errorResponse["errors"][0]
-  }
+	if len(errorResponse["errors"]) > 0 {
+		return errorResponse["errors"][0]
+	}
 
-  return ""
+	return ""
 }
 
 func get(url string, obj interface{}) error {
-  resp, err  := http.Get(url)
+	resp, err := http.Get(url)
 
-  if err != nil {
-    trace("error GET %s", err)
-    return err
-  }
+	if err != nil {
+		trace("error GET %s", err)
+		return err
+	}
 
-  if resp.StatusCode != 200 {
-    trace("error status code %d", resp.StatusCode)
-    
-    errMessage := getError(resp.Body)
-    if len(errMessage) > 0 {
-      return errors.New(errMessage)
-    }
-    return errors.New(fmt.Sprintf("status code %d", resp.StatusCode))
-  }
+	if resp.StatusCode != 200 {
+		trace("error status code %d", resp.StatusCode)
 
-  defer resp.Body.Close()
+		errMessage := getError(resp.Body)
+		if len(errMessage) > 0 {
+			return errors.New(errMessage)
+		}
+		return errors.New(fmt.Sprintf("status code %d", resp.StatusCode))
+	}
 
-  readBody(resp.Body, &obj)
+	defer resp.Body.Close()
 
-  return nil
+	readBody(resp.Body, &obj)
+
+	return nil
 }
 
 func readBody(responseBody io.ReadCloser, obj interface{}) error {
-  body, err := ioutil.ReadAll(responseBody);
-  if err != nil {
-    return err
-  }
+	body, err := ioutil.ReadAll(responseBody)
+	if err != nil {
+		return err
+	}
 
-  if err := json.Unmarshal(body, &obj); err != nil {
-    trace("error %s", err)
-    return err
-  }
+	if err := json.Unmarshal(body, &obj); err != nil {
+		trace("error %s", err)
+		return err
+	}
 
-  return nil
+	return nil
 }


### PR DESCRIPTION
Formats the codebase according to the Go coding standards via the `go fmt` command.
